### PR TITLE
Initialize React and Express skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # board-games-library
-A web app for storing and organising your board game library
+
+A web app for storing and organising your board game collection.
+
+## Development setup
+
+This repository contains two directories:
+
+- `client` &ndash; React frontend built with [Vite](https://vitejs.dev/) and Tailwind CSS.
+- `server` &ndash; Express proxy server used to query the BoardGameGeek API.
+
+Both folders contain their own `package.json`. Install dependencies in each folder and run the development servers separately.
+
+```bash
+cd client && npm install
+npm run dev
+```
+
+```bash
+cd server && npm install
+npm run dev
+```
+
+The frontend dev server proxies API requests starting with `/api` to `http://localhost:3001`.
+
+## Stage&nbsp;1 plan
+
+1. **Search** &ndash; Allow users to search for board games using BoardGameGeek's API. The server exposes `/api/search?q=<term>` which converts the XML response to JSON.
+2. **Library management** &ndash; Enable selecting games from search results and storing them in `localStorage`.
+3. **Library view** &ndash; Display the saved list of games on a dedicated page.
+4. **Styling** &ndash; Use Tailwind CSS for basic layout and style.
+
+Later stages will introduce authentication and a persistent database for storing each user's library.
+
+## Recommended CSS framework
+
+[Tailwind CSS](https://tailwindcss.com/) is used for rapid styling and utility classes.

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Board Games Library</title>
+  </head>
+  <body class="min-h-screen bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "client",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.3.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.4.0",
+    "postcss": "^8.4.21",
+    "autoprefixer": "^10.4.14"
+  }
+}

--- a/client/postcss.config.cjs
+++ b/client/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,0 +1,3 @@
+#root {
+  min-height: 100vh;
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,16 @@
+import { useState } from 'react'
+import './App.css'
+
+function App() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold mb-4">Board Games Library</h1>
+      {/* TODO: Implement search and library views */}
+      <p>Coming soon...</p>
+    </div>
+  )
+}
+
+export default App

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/client/tsconfig.node.json
+++ b/client/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001'
+    }
+  }
+})

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,35 @@
+import express from 'express'
+import fetch from 'node-fetch'
+import { parseStringPromise } from 'xml2js'
+import cors from 'cors'
+
+const app = express()
+const PORT = process.env.PORT || 3001
+
+app.use(cors())
+
+app.get('/api/search', async (req, res) => {
+  const query = req.query.q
+  if (!query) {
+    return res.status(400).json({ error: 'Missing query' })
+  }
+  try {
+    const response = await fetch(`https://api.geekdo.com/xmlapi2/search?query=${encodeURIComponent(query)}&type=boardgame`)
+    const xml = await response.text()
+    const result = await parseStringPromise(xml, { explicitArray: false })
+    const items = result.items && result.items.item ? result.items.item : []
+    const games = Array.isArray(items) ? items : [items]
+    res.json(games.map(g => ({
+      id: g.$.id,
+      name: g.name.$.value,
+      yearpublished: g.yearpublished?.$.value
+    })))
+  } catch (err) {
+    console.error(err)
+    res.status(500).json({ error: 'Failed to fetch data' })
+  }
+})
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`)
+})

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "server",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2",
+    "xml2js": "^0.5.0",
+    "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}


### PR DESCRIPTION
## Summary
- set up `client` React app with Vite + Tailwind
- add `server` Express proxy to query BoardGameGeek
- document Stage 1 plan in README

## Testing
- `npm test` *(fails: Missing script)* for `client`
- `npm test` *(fails: Missing script)* for `server`


------
https://chatgpt.com/codex/tasks/task_b_6877da53322c83339e46619c4fa73c3c