### PR TITLE
Implement search UI with images

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,69 @@
 import { useState } from 'react'
 import './App.css'
 
+interface Game {
+  id: string
+  name: string
+  yearpublished?: string
+  image?: string
+}
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<Game[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const handleSearch = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!query.trim()) return
+    setLoading(true)
+    try {
+      const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`)
+      const data = await res.json()
+      setResults(data.slice(0, 10))
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
 
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">Board Games Library</h1>
-      {/* TODO: Implement search and library views */}
-      <p>Coming soon...</p>
+
+      <form onSubmit={handleSearch} className="mb-4 flex gap-2">
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search board games"
+          className="border p-2 flex-grow"
+        />
+        <button
+          type="submit"
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Search
+        </button>
+      </form>
+
+      {loading && <p>Loading...</p>}
+
+      <ul>
+        {results.map((game) => (
+          <li key={game.id} className="flex items-center mb-2">
+            {game.image && (
+              <img
+                src={game.image}
+                alt=""
+                className="w-12 h-12 object-cover mr-2"
+              />
+            )}
+            <span>{game.name}</span>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/server/index.js
+++ b/server/index.js
@@ -14,16 +14,45 @@ app.get('/api/search', async (req, res) => {
     return res.status(400).json({ error: 'Missing query' })
   }
   try {
-    const response = await fetch(`https://api.geekdo.com/xmlapi2/search?query=${encodeURIComponent(query)}&type=boardgame`)
+    const response = await fetch(
+      `https://api.geekdo.com/xmlapi2/search?query=${encodeURIComponent(query)}&type=boardgame`
+    )
     const xml = await response.text()
     const result = await parseStringPromise(xml, { explicitArray: false })
     const items = result.items && result.items.item ? result.items.item : []
     const games = Array.isArray(items) ? items : [items]
-    res.json(games.map(g => ({
-      id: g.$.id,
-      name: g.name.$.value,
-      yearpublished: g.yearpublished?.$.value
-    })))
+
+    const limited = games.slice(0, 10)
+    const ids = limited.map(g => g.$.id)
+    let images = {}
+
+    if (ids.length) {
+      const detailRes = await fetch(
+        `https://api.geekdo.com/xmlapi2/thing?id=${ids.join(',')}`
+      )
+      const detailXml = await detailRes.text()
+      const detailResult = await parseStringPromise(detailXml, {
+        explicitArray: false
+      })
+      const detailItems =
+        detailResult.items && detailResult.items.item
+          ? detailResult.items.item
+          : []
+      const detailList = Array.isArray(detailItems) ? detailItems : [detailItems]
+      images = detailList.reduce((acc, item) => {
+        acc[item.$.id] = item.image
+        return acc
+      }, {})
+    }
+
+    res.json(
+      limited.map(g => ({
+        id: g.$.id,
+        name: g.name.$.value,
+        yearpublished: g.yearpublished?.$.value,
+        image: images[g.$.id]
+      }))
+    )
   } catch (err) {
     console.error(err)
     res.status(500).json({ error: 'Failed to fetch data' })


### PR DESCRIPTION
## Summary
- extend `/api/search` to fetch board game images from BoardGame Geek
- add a search interface in `App.tsx` that queries the backend and lists results

## Testing
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877dfeebfbc8333ba45a83561f23685