### PR TITLE
Fix API error handling and tighten result limit

### DIFF
--- a/client/src/hooks/useSearch.ts
+++ b/client/src/hooks/useSearch.ts
@@ -16,7 +16,7 @@ export default function useSearch(query: string) {
       try {
         const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`)
         const data = await res.json()
-        setResults(data.slice(0, 24))
+        setResults(data.slice(0, 20))
       } catch (err) {
         console.error(err)
       } finally {

--- a/server/services/boardGameService.js
+++ b/server/services/boardGameService.js
@@ -2,13 +2,20 @@ import fetch from 'node-fetch'
 import { parseStringPromise } from 'xml2js'
 import Game from '../models/game.js'
 
-const LIMIT = 24
+const LIMIT = 20
 
 export async function fetchSearchResults(query) {
   const response = await fetch(
     `https://api.geekdo.com/xmlapi2/search?query=${encodeURIComponent(query)}&type=boardgame`
   )
   const xml = await response.text()
+  if (!response.ok) {
+    console.error(
+      `Error fetching search results: ${response.status} ${response.statusText}`
+    )
+    console.error(xml)
+    throw new Error('Failed to fetch search results')
+  }
   const result = await parseStringPromise(xml, { explicitArray: false })
   const items = result.items && result.items.item ? result.items.item : []
   const games = Array.isArray(items) ? items : [items]
@@ -22,6 +29,13 @@ export async function fetchSearchResults(query) {
       `https://api.geekdo.com/xmlapi2/thing?id=${ids.join(',')}`
     )
     const detailXml = await detailRes.text()
+    if (!detailRes.ok) {
+      console.error(
+        `Error fetching game details: ${detailRes.status} ${detailRes.statusText}`
+      )
+      console.error(detailXml)
+      throw new Error('Failed to fetch game details')
+    }
     const detailResult = await parseStringPromise(detailXml, { explicitArray: false })
     const detailItems =
       detailResult.items && detailResult.items.item ? detailResult.items.item : []


### PR DESCRIPTION
## Summary
- handle failed boardgame API responses
- reduce search result limit to 20

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_68827ad628888333a2934c11a4debb51